### PR TITLE
Shaders to matrials

### DIFF
--- a/FragmentShader/PBR/PBR-IBL-Textured-Fragment.glsl
+++ b/FragmentShader/PBR/PBR-IBL-Textured-Fragment.glsl
@@ -165,12 +165,12 @@ void main()
 {
     //sampler the texture maps
     albedo = texture(_albedoMap, fs_in.TexCoords).rgb;
-    if(fs_in.isModel != 0.0){
-        roughness = texture(_roughnessMap, fs_in.TexCoords).r;
-        metallic = texture(_metallicMap, fs_in.TexCoords).r;
-    }else{
+    if(fs_in.isModel == 1.0){
         roughness = texture(_rougnessMetalnessMap, fs_in.TexCoords).g;
         metallic = texture(_rougnessMetalnessMap, fs_in.TexCoords).b;
+    }else{
+        roughness = texture(_roughnessMap, fs_in.TexCoords).r;
+        metallic = texture(_metallicMap, fs_in.TexCoords).r;
     }
     emmisive = texture(_emmisionMap, fs_in.TexCoords).rgb;
     ao = texture(_aoMap, fs_in.TexCoords).r;
@@ -249,11 +249,11 @@ void main()
     if(fs_in.reciviesShadow == 1){
         shadow = caclualteShadow(fs_in.FragPosLight,shadowBias);
     }else{
-        shadow = 0.5;
+        shadow = 0.6;
     }
     vec3 irradiance = texture(irradianceMap, N).rgb;
 
-    vec3 diffuse = (irradiance * albedo)*1-shadow;
+    vec3 diffuse = (irradiance * albedo)*(1-shadow);
 
     const float MAX_REFLECTION_LOD = 4.0;
     vec3 prefilterColor = textureLod(prefilterMap, R, roughness * MAX_REFLECTION_LOD).rgb;

--- a/FragmentShader/PBR/PBR-IBL-Textured-Fragment.glsl
+++ b/FragmentShader/PBR/PBR-IBL-Textured-Fragment.glsl
@@ -1,0 +1,274 @@
+#version 460 core
+
+out vec4 FragColor;
+
+in VS_OUT {
+    vec3 FragPos;
+    vec3 Normal;
+    vec2 TexCoords;
+    vec4 FragPosLight;
+    mat3 TBN;
+    float isModel;
+    float hasEmission;
+    float reciviesShadow;
+    float hasNormalMap;
+}fs_in;
+
+uniform samplerCube irradianceMap;
+uniform samplerCube prefilterMap;
+uniform sampler2D BRDFtexture;
+
+uniform vec3 lightPositions[5];
+uniform vec3 lightColors[5];
+uniform vec3 camPos;
+uniform sampler2D shadowMap;
+
+vec3  albedo;
+float metallic;
+float roughness;
+float ao;
+vec3 emmisive;
+
+uniform sampler2D _albedoMap;
+uniform sampler2D _roughnessMap;
+uniform sampler2D _metallicMap;
+uniform sampler2D _normalMap;
+uniform sampler2D _aoMap;
+uniform sampler2D _rougnessMetalnessMap;
+uniform sampler2D _emmisionMap;
+
+
+const float PI = 3.14159265359;
+
+float caclualteShadow(vec4 FragPosLight, float bias)
+{
+    //tranfsforms fragment position in ragne from [0, 1]
+    vec3 projCoords = FragPosLight.xyz / FragPosLight.w;
+    projCoords = projCoords * 0.5 + 0.5;
+
+    //get the closest depth value from the shadow map
+    //closest object to the light
+    float closestDepth = texture(shadowMap, projCoords.xy).w;
+
+    //get the depth value of the current fragment
+    float currentDepth = projCoords.z;
+
+    //compare if current depth value is bigger than the closest depth value
+    // is true object is not in the shadow (1.0)
+    // if false object is in the shadow (0.0)
+    float shadow = 0;
+
+    //this will be used for sampling neiborough texels in mipmap level 0
+    vec2 texelSize = 1.0 / textureSize(shadowMap, 0);
+
+    // creates 3x3 grid around the sampled texel
+    for(int x = -1; x <= 1; ++x)
+    {
+        for(int y = -1; y <= 1; ++y)
+        {
+            //sample the surounding texel
+            //the multiplication by texelSize is necesary since the shadow map is in different resolution
+            float pcfDepth = texture(shadowMap, projCoords.xy + vec2(x, y) * texelSize).r;
+            shadow += currentDepth - bias > pcfDepth ? 1.0 : 0.0;
+        }
+    }
+    //calculate the average
+    shadow /= 9.0;
+
+    if(projCoords.z > 1.0)
+    shadow = 0.0;
+
+    return shadow;
+
+}
+
+
+// caclulate how much light geths reflected vs how much light gets refracted
+//cosThete = angle we are looking at the surface
+//F0 = how much surface reflects when looking directly at it (big database)
+vec3 FresnelShlick(float cosTheta, vec3 F0)
+{
+    return F0 + (1.0 - F0) * pow(1.0 - cosTheta, 5.0);
+}
+
+vec3 FresnelShlickRoughness(float cosTheta, vec3 F0, float roughness)
+{
+    return F0 + (max(vec3(1.0 - roughness), F0) - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+}
+
+vec3 getNormalFromMap()
+{
+    vec3 tangentNormal = texture(_normalMap, fs_in.TexCoords).xyz * 2.0 - 1.0;
+
+    vec3 Q1  = dFdx(fs_in.FragPos);
+    vec3 Q2  = dFdy(fs_in.FragPos);
+    vec2 st1 = dFdx(fs_in.TexCoords);
+    vec2 st2 = dFdy(fs_in.TexCoords);
+
+    vec3 N   = normalize(fs_in.Normal);
+    vec3 T  = normalize(Q1*st2.t - Q2*st1.t);
+    vec3 B  = -normalize(cross(N, T));
+    mat3 TBN = mat3(T, B, N);
+
+    return normalize(TBN * tangentNormal);
+}
+
+// N in the eqation
+// N = normal vector
+// H = halfway vector
+float DistributionFunctionGGX(vec3 N, vec3 H, float roughtness)
+{
+    float a = roughness * roughtness;
+    float a2 = a*a;
+    float NdotH = max(dot(N,H),0.0);
+    float NdotH2 = NdotH * NdotH;
+
+    //top part of fraction
+    float num = a2;
+
+    //bottom part of the fraction
+    float denom = (NdotH2 * (a2 -1.0) + 1.0);
+    denom = PI * denom * denom;
+
+    return num/denom;
+}
+
+float GeometryShclickGGX(float NdotVorL, float roughness)
+{
+    float r = (roughness + 1.0);
+    //roughtness parameter based on type of light
+    float k = (r * r)/8;
+
+    //top part of the fraction
+    float num = NdotVorL;
+
+    //bottom part of the fraction
+    float denom = NdotVorL * (1.0 - k) + k;
+
+    return num/denom;
+}
+
+float GeometrySmith(vec3 N, vec3 V, vec3 L, float roughness)
+{
+    //for view direction
+    float NdotV = max(dot(N,V),0.0);
+    float ggx2 = GeometryShclickGGX(NdotV, roughness);
+
+    //for light direction
+    float NdotL = max(dot(N,L), 0.0);
+    float ggx1 = GeometryShclickGGX(NdotL, roughness);
+
+    return ggx1 * ggx2;
+}
+
+void main()
+{
+    //sampler the texture maps
+    albedo = texture(_albedoMap, fs_in.TexCoords).rgb;
+    if(fs_in.isModel != 0.0){
+        roughness = texture(_roughnessMap, fs_in.TexCoords).r;
+        metallic = texture(_metallicMap, fs_in.TexCoords).r;
+    }else{
+        roughness = texture(_rougnessMetalnessMap, fs_in.TexCoords).g;
+        metallic = texture(_rougnessMetalnessMap, fs_in.TexCoords).b;
+    }
+    emmisive = texture(_emmisionMap, fs_in.TexCoords).rgb;
+    ao = texture(_aoMap, fs_in.TexCoords).r;
+    vec3 N = getNormalFromMap();
+
+    //normal
+    //vec3 N = normalize(fs_in.Normal);
+    //N = normalize(fs_in.Normal);
+    //view direction;
+    vec3 V = normalize(camPos - fs_in.FragPos);
+
+    //reflect the view direction around the normal vector
+    vec3 R = reflect(-V, N);
+
+    //metalness of the material
+    vec3 F0 = vec3(0.04);
+    F0 = mix(F0, albedo, metallic);
+
+    //result
+    vec3 Lo = vec3(0.0);
+
+    vec3 L;
+
+    for(int i = 0; i<5 ; i++)
+    {
+        //light direction
+        L = normalize(lightPositions[i] - fs_in.FragPos);
+
+        //hallfway vector;
+        vec3 H = normalize(V + L);
+
+        //attentuation
+        float distance = length(lightPositions[i] - fs_in.FragPos);
+        float attentuation = 1.0/(distance * distance);
+        vec3 radiance = lightColors[i] * attentuation;
+
+        //DFG eqation
+        float NDF = DistributionFunctionGGX(N,H, roughness);
+        float G = GeometrySmith(N,V,L, roughness);
+        vec3 F = FresnelShlick(max(dot(H, V), 0.0), F0);
+
+        //Cook tolerance
+        //for working with metallic materials
+        //specifiing the metallness of the object
+        vec3 numerator = NDF * G * F;
+        float denominator = 4.0 * max(dot(N,V), 0.0) * max(dot(N,L), 0.0);
+
+        //calculate the specular component
+        vec3 specular = numerator / max(denominator, 0.001);
+
+        //calculate the ammount that gets refracted and what gets reflected
+        vec3 kS = F;
+        vec3 kD = vec3(1.0) - kS;
+
+        // if surface is metllic nullify the diffuse component
+        kD *= 1.0 - metallic;
+
+        //calculate the final rendering eqation
+        float NdotL = max(dot(N,L), 0.0);
+        Lo += (kD * albedo /PI + specular) * radiance * NdotL;
+    }
+
+    //----------------------
+    // IMAGE BASED LIGHTING
+    //----------------------
+    vec3 F = FresnelShlickRoughness(max(dot(N,V),0.0), F0, roughness);
+
+    vec3 kS = F;
+    vec3 kD = vec3(1.0) - kS;
+    kD *= 1.0 - metallic;
+
+    float shadowBias = max(0.09 * (1.0 - dot(N, L)), 0.05);
+
+    float shadow;
+
+    if(fs_in.reciviesShadow == 1){
+        shadow = caclualteShadow(fs_in.FragPosLight,shadowBias);
+    }else{
+        shadow = 0.5;
+    }
+    vec3 irradiance = texture(irradianceMap, N).rgb;
+
+    vec3 diffuse = (irradiance * albedo)*1-shadow;
+
+    const float MAX_REFLECTION_LOD = 4.0;
+    vec3 prefilterColor = textureLod(prefilterMap, R, roughness * MAX_REFLECTION_LOD).rgb;
+
+    vec2 brdf = texture(BRDFtexture, vec2(max(dot(N,V), 0.0), roughness)).rg;
+    vec3 specular = (prefilterColor * (kS * brdf.x +  brdf.y));
+
+    vec3 ambient = (kD * diffuse + specular ) *(1-shadow);
+    if(fs_in.hasEmission == 1.0){
+        ambient += ( 4.0 * emmisive);
+    }
+    vec3 color = ambient + Lo;
+
+    //HDR
+    color = color / (color + vec3(1.0));
+
+    FragColor = vec4(color, 1.0);
+}

--- a/FragmentShader/PBR/PBRFragment-Textured-Model.glsl
+++ b/FragmentShader/PBR/PBRFragment-Textured-Model.glsl
@@ -24,6 +24,8 @@ uniform vec3 lightPositions[5];
 uniform vec3 lightColors[5];
 uniform vec3 camPos;
 
+uniform float isModel;
+
 const float PI = 3.14159265359;
 
 vec3 getNormalFromMap()

--- a/Includes/Renderer/Material/PBRColor/PBRColor.cpp
+++ b/Includes/Renderer/Material/PBRColor/PBRColor.cpp
@@ -4,7 +4,9 @@
 
 #include "PBRColor.h"
 
-PBRColor::PBRColor(std::shared_ptr<Shader> shader, glm::vec3 albedo, float metallic, float rougness, float ao, std::string shaderNamingConvention): Material(std::move(shader)) {
+PBRColor::PBRColor(glm::vec3 albedo, float metallic, float rougness, float ao, std::string shaderNamingConvention): Material(std::move(shader)) {
+    this->shader = std::make_shared<Shader>("VertexShader/PBR/PBRVertex-Simple.glsl", "FragmentShader/PBR/PBRFragment.glsl", "PBR shader color");
+
     this->albedo = std::make_unique<PBRMaterial<glm::vec3>>(albedo, "Albedo");
     this->rougness = std::make_unique<PBRMaterial<float>>(rougness, shaderNamingConvention + "Rougness");
     this->metalness = std::make_unique<PBRMaterial<float>>(metallic, shaderNamingConvention + "Metalness");

--- a/Includes/Renderer/Material/PBRColor/PBRColor.h
+++ b/Includes/Renderer/Material/PBRColor/PBRColor.h
@@ -22,7 +22,7 @@ public:
      * @param ao ambient occulsion value
      * @param shaderNamingConvention naming convention of the shader defualt is _val eg: _valAlbedo, _valMetallic
      */
-    explicit PBRColor(std::shared_ptr<Shader> shader, glm::vec3 albedo = glm::vec3(0.4f, 0.4f, 0.4f), float metallic = 0.7f , float rougness = 0.2f, float ao= 0.6f, std::string shaderNamingConvention = "_val");
+    explicit PBRColor(glm::vec3 albedo = glm::vec3(0.4f, 0.4f, 0.4f), float metallic = 0.7f , float rougness = 0.2f, float ao= 0.6f, std::string shaderNamingConvention = "_val");
 private:
     std::unique_ptr<PBRMaterial<glm::vec3>> albedo;
     std::unique_ptr<PBRMaterial<float>> metalness;

--- a/Includes/Renderer/Material/PBRTexture/PBRTextured.cpp
+++ b/Includes/Renderer/Material/PBRTexture/PBRTextured.cpp
@@ -4,7 +4,7 @@
 
 #include "PBRTextured.h"
 
-PBRTextured::PBRTextured(std::string pathToTheDirectory,bool supportsIBL, std::string shaderNamingConvention, std::string fileFormat): Material(std::move(shader)) {
+PBRTextured::PBRTextured(std::string pathToTheDirectory,bool supportsIBL, std::string shaderNamingConvention, std::string fileFormat): Material() {
     std::string fullPath;
     std::unique_ptr<Texture2D> texture;
     this->shader = std::make_shared<Shader>("VertexShader/PBR/PBRVertex.glsl","FragmentShader/PBR/PBR-IBL-Textured-Fragment.glsl", "PBR-IBL-Shader");
@@ -41,6 +41,7 @@ PBRTextured::PBRTextured(std::string pathToTheDirectory,bool supportsIBL, std::s
     texture = std::make_unique<Texture2D>(fullPath.c_str(), true);
     this->addTexture(std::make_unique<PBRMaterial<Texture2D>>(std::move(texture), shaderNamingConvention + "displacementMap", 5));
 
+    this->hasEmissionTexture = false;
 }
 
 void PBRTextured::configureShader() {

--- a/Includes/Renderer/Material/PBRTexture/PBRTextured.cpp
+++ b/Includes/Renderer/Material/PBRTexture/PBRTextured.cpp
@@ -4,9 +4,12 @@
 
 #include "PBRTextured.h"
 
-PBRTextured::PBRTextured(std::shared_ptr<Shader> shader, std::string pathToTheDirectory, std::string shaderNamingConvention, std::string fileFormat): Material(std::move(shader)) {
+PBRTextured::PBRTextured(std::string pathToTheDirectory,bool supportsIBL, std::string shaderNamingConvention, std::string fileFormat): Material(std::move(shader)) {
     std::string fullPath;
     std::unique_ptr<Texture2D> texture;
+    this->shader = std::make_shared<Shader>("VertexShader/PBR/PBRVertex.glsl","FragmentShader/PBR/PBR-IBL-Textured-Fragment.glsl", "PBR-IBL-Shader");
+    this->shader->supportsIBL = supportsIBL;
+    this->supportsIBL = supportsIBL;
 
     // Albedo map
     fullPath = pathToTheDirectory + "/albedo" + fileFormat;
@@ -59,7 +62,10 @@ void PBRTextured::addTexture(std::unique_ptr<PBRMaterial<Texture2D>> texture) {
 }
 
 
-PBRTextured::PBRTextured(std::shared_ptr<Shader> shader) : Material(std::move(shader)) {
+PBRTextured::PBRTextured(bool supportsIBL) : Material() {
+    this->shader = std::make_shared<Shader>("VertexShader/PBR/PBRVertex.glsl","FragmentShader/PBR/PBR-IBL-Textured-Fragment.glsl", "PBR-IBL-Shader");
+    this->shader->supportsIBL = supportsIBL;
+    this->supportsIBL = supportsIBL;
 }
 
 

--- a/Includes/Renderer/Material/PBRTexture/PBRTextured.h
+++ b/Includes/Renderer/Material/PBRTexture/PBRTextured.h
@@ -46,8 +46,6 @@ public:
     void addTexture(std::unique_ptr<PBRMaterial<Texture2D>> texture);
 
     bool hasEmissionTexture = false;
-    bool isIBL;
-    ~PBRTextured()= default;
 
 private:
     /***

--- a/Includes/Renderer/Material/PBRTexture/PBRTextured.h
+++ b/Includes/Renderer/Material/PBRTexture/PBRTextured.h
@@ -26,13 +26,13 @@ public:
      * @param shader shader that will be assosiated with texture
      * @param shaderNamingConvention naming conventions used in the shader for unifrom samplers
      * */
-    explicit PBRTextured(std::shared_ptr<Shader> shader, std::string pathToTheDirectory,  std::string shaderNamingConvention = "_", std::string fileFormat = ".png");
+    explicit PBRTextured(std::string pathToTheDirectory,bool supportsIBL = true,  std::string shaderNamingConvention = "_", std::string fileFormat = ".png");
 
     /***
      * Creates empty instance of the class
      * @param shader shader the material should use
      */
-    explicit PBRTextured(std::shared_ptr<Shader> shader);
+    explicit PBRTextured(bool supportsIBL = true);
 
     /***
      * Passes all information to the shader unifroms
@@ -45,8 +45,8 @@ public:
      */
     void addTexture(std::unique_ptr<PBRMaterial<Texture2D>> texture);
 
-    bool hasEmissionTexture;
-
+    bool hasEmissionTexture = false;
+    bool isIBL;
     ~PBRTextured()= default;
 
 private:

--- a/Includes/Renderer/Material/SkyBoxMaterial/SkyBoxMaterial.cpp
+++ b/Includes/Renderer/Material/SkyBoxMaterial/SkyBoxMaterial.cpp
@@ -6,7 +6,8 @@
 
 #include <utility>
 
-SkyBoxMaterial::SkyBoxMaterial(std::shared_ptr<Shader> shader, TextureBase skyBox, std::string shaderName):Material(std::move(shader)) {
+SkyBoxMaterial::SkyBoxMaterial(TextureBase skyBox, std::string shaderName):Material() {
+    this->shader = std::make_shared<Shader>("VertexShader/PBR/SkyBoxVertex.glsl", "FragmentShader/PBR/SkyBoxFragment.glsl", "Sky box shader");
     this->cubeMapUnifrom = new CubeMapUnifrom(std::move(skyBox), std::move(shaderName));
     this->cubeMapUnifrom->cubeMap.setSamplerID(0);
 }

--- a/Includes/Renderer/Material/SkyBoxMaterial/SkyBoxMaterial.h
+++ b/Includes/Renderer/Material/SkyBoxMaterial/SkyBoxMaterial.h
@@ -31,7 +31,7 @@ struct CubeMapUnifrom {
  */
 class SkyBoxMaterial : public Material {
 public:
-    SkyBoxMaterial(std::shared_ptr<Shader> shader, TextureBase skyBox, std::string shaderName);
+    SkyBoxMaterial(TextureBase skyBox, std::string shaderName);
     /**
     * passes all relevant uniform to the shader
     */

--- a/Includes/Renderer/Renderable/Renderable.cpp
+++ b/Includes/Renderer/Renderable/Renderable.cpp
@@ -31,13 +31,16 @@ Renderable::Renderable(std::shared_ptr<Geometry> geometry, std::shared_ptr<Mater
 
 Renderable::Renderable(std::shared_ptr<Shader> shader) {
     //default values
-    this->objectMaterial = std::make_unique<PBRColor>(std::move(shader));
+    this->objectMaterial = std::make_unique<PBRColor>();
     this->objectGeometry = std::make_unique<CubeGeometry>();
     this->modelMatrix = glm::mat4(1.0f);
     this->transformations = std::make_unique<Transformations>();
 }
 
 void Renderable::render() {
+    this->objectMaterial->shader->use();
+    this->objectMaterial->shader->setFloat("isModel", this->isModel);
+    this->objectMaterial->shader->setFloat("reciviesShadow", this->recievesShadow);
     this->objectMaterial->configureShader();
     this->objectGeometry->render();
 }

--- a/Includes/Renderer/Renderable/Renderable.h
+++ b/Includes/Renderer/Renderable/Renderable.h
@@ -30,6 +30,7 @@ public:
     std::unique_ptr<Transformations> transformations;
     bool castsShadwo = false;
     bool recievesShadow = false;
+    bool isModel = false;
     const std::shared_ptr<Material> &getObjectMaterial() const;
     bool isPartOfSceneNode = false;
 protected:

--- a/Includes/Renderer/SceneGraph/Floor/Floor.cpp
+++ b/Includes/Renderer/SceneGraph/Floor/Floor.cpp
@@ -5,8 +5,8 @@
 #include "Floor.h"
 
 Floor::Floor(): SceneNode(){
-    auto floorShader = std::make_shared<Shader>("VertexShader/PBR/PBRVertex.glsl", "FragmentShader/PBR/PBR-FloorFragment.glsl", "PBR floor");
-    auto mat = std::make_unique<PBRTextured>(floorShader,"Assets/Textures/PBR/ForestRock");
+    auto floorShader = std::make_shared<Shader>("VertexShader/PBR/PBRVertex-Simple.glsl", "FragmentShader/PBR/PBR-FloorFragment.glsl", "PBR floor");
+    auto mat = std::make_unique<PBRTextured>("Assets/Textures/PBR/ForestRock");
     auto geometry = std::make_unique<PlaneGeometry>();
     auto floorRenderable = std::make_unique<Renderable>(std::move(geometry), std::move(mat));
     this->addChild(std::make_unique<SceneNode>(std::move(floorRenderable)));

--- a/Includes/Renderer/SceneGraph/ModelSceneNode/ModelSceneNode.cpp
+++ b/Includes/Renderer/SceneGraph/ModelSceneNode/ModelSceneNode.cpp
@@ -6,8 +6,7 @@
 
 #include <utility>
 
-ModelSceneNode::ModelSceneNode(std::shared_ptr<Shader> shader, std::string path, std::shared_ptr<PBRTextured> mat): SceneNode() {
-    this->shader = std::move(shader);
+ModelSceneNode::ModelSceneNode(std::string path, std::shared_ptr<PBRTextured> mat): SceneNode() {
     Assimp::Importer importer;
 
     this->material = std::move(mat);
@@ -110,6 +109,7 @@ void ModelSceneNode::processRenderable(aiMesh *mesh, const aiScene *scene) {
         renderableMaterial = this->material;
 
     std::unique_ptr<Renderable> processedRenderable = std::make_unique<Renderable>(std::move(renderableGeometry), renderableMaterial, mesh->mName.C_Str());
+    processedRenderable->isModel = true;
 
     std::unique_ptr<SceneNode> processedNode = std::make_unique<SceneNode>(std::move(processedRenderable));
 
@@ -117,7 +117,7 @@ void ModelSceneNode::processRenderable(aiMesh *mesh, const aiScene *scene) {
 }
 
 std::unique_ptr<PBRTextured>ModelSceneNode::processRenderableMaterial(aiMaterial *meshMaterial) {
-    std::unique_ptr<PBRTextured> mat = std::make_unique<PBRTextured>(shader);
+    std::unique_ptr<PBRTextured> mat = std::make_unique<PBRTextured>();
 
     mat->addTexture(this->processMaterialProperty(meshMaterial, aiTextureType_DIFFUSE , "_albedoMap", 0));
 

--- a/Includes/Renderer/SceneGraph/ModelSceneNode/ModelSceneNode.h
+++ b/Includes/Renderer/SceneGraph/ModelSceneNode/ModelSceneNode.h
@@ -15,7 +15,7 @@
 
 class ModelSceneNode:public SceneNode  {
 public:
-    explicit ModelSceneNode(std::shared_ptr<Shader> shader, std::string path, std::shared_ptr<PBRTextured> mat = nullptr);
+    explicit ModelSceneNode( std::string path, std::shared_ptr<PBRTextured> mat = nullptr);
     std::string directory;
 
     /***

--- a/Includes/Renderer/SceneGraph/Scene.cpp
+++ b/Includes/Renderer/SceneGraph/Scene.cpp
@@ -3,10 +3,11 @@
 //
 
 #include "Scene.h"
+#include "Renderer/Utils/GLFWHelper/GLFWHelper.h"
 
 Scene::Scene() {
     Scene::root = std::make_shared<SceneNode>();
-    this->camera = std::make_unique<Camera>(glm::vec3(0.0f, 0.0f, 3.0f));
+    this->camera = std::make_unique<Camera>(GLFWHelper::getScreenWidth(), GLFWHelper::getScreenHeight(),glm::vec3(0.0f, 0.0f, 3.0f));
     this->light = std::make_unique<Light>(glm::vec3(0.0f, 3.0f, 3.0f), glm::vec3(20.0f, 20.0f, 20.2f));
 }
 

--- a/Includes/Renderer/Utils/GLFWHelper/GLFWHelper.cpp
+++ b/Includes/Renderer/Utils/GLFWHelper/GLFWHelper.cpp
@@ -86,12 +86,6 @@ bool GLFWHelper::glInit(unsigned int width, unsigned int height) {
     glfwSetScrollCallback(instance->getWindow(), scroll_callback);
     glfwSetInputMode(instance->getWindow(), GLFW_CURSOR, GLFW_CURSOR_DISABLED);
     glfwSetWindowRefreshCallback(instance->getWindow(), processResize);
-    glfwGetWindowSize(instance->getWindow(), &screen_W, &screen_H);
-
-    int size;
-    glGetIntegerv(GL_MAX_TEXTURE_SIZE,&size);
-
-    std::cout<<size;
 
     return true;
 }

--- a/Includes/Renderer/Utils/GLFWHelper/GLFWHelper.h
+++ b/Includes/Renderer/Utils/GLFWHelper/GLFWHelper.h
@@ -13,8 +13,8 @@ private:
     inline static PabloRenderer *instance;
     inline static float pointerX = 0;
     inline static float pointerY = 0;
-    inline static int screen_W = 1300;
-    inline static int screen_H = 900;
+    inline static int screen_W = 800;
+    inline static int screen_H = 600;
 public:
     inline static void setInstance(PabloRenderer* inst){
         instance = inst;

--- a/Includes/camera.h
+++ b/Includes/camera.h
@@ -43,13 +43,13 @@ public:
     float Zoom;
 
     // constructor with vectors
-    Camera(glm::vec3 position = glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3 up = glm::vec3(0.0f, 1.0f, 0.0f), float yaw = YAW, float pitch = PITCH) : Front(glm::vec3(0.0f, 0.0f, -1.0f)), MovementSpeed(SPEED), MouseSensitivity(SENSITIVITY), Zoom(ZOOM)
+    Camera(int screenWidht= 600, int screenHeight = 800,glm::vec3 position = glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3 up = glm::vec3(0.0f, 1.0f, 0.0f), float yaw = YAW, float pitch = PITCH ) : Front(glm::vec3(0.0f, 0.0f, -1.0f)), MovementSpeed(SPEED), MouseSensitivity(SENSITIVITY), Zoom(ZOOM)
     {
         Position = position;
         WorldUp = up;
         Yaw = yaw;
         Pitch = pitch;
-        this->projection = glm::perspective(glm::radians(this->Zoom), (float)800 / (float)600, 0.1f, 70.0f);
+        this->projection = glm::perspective(glm::radians(this->Zoom), (float)screenHeight / (float)screenWidht, 0.1f, 70.0f);
         updateCameraVectors();
     }
     // constructor with scalar values

--- a/VertexShader/PBR/PBRVertex-Simple.glsl
+++ b/VertexShader/PBR/PBRVertex-Simple.glsl
@@ -22,9 +22,6 @@ out VS_OUT {
     vec2 TexCoords;
     vec4 FragPosLight;
     mat3 TBN;
-    float isModel;
-    float hasEmission;
-    float reciviesShadow;
     float hasNormalMap;
 }vs_out;
 
@@ -32,12 +29,12 @@ void main()
 {
     mat3 normalMatrix = transpose(inverse(mat3(model)));
 
-    // transform the vectors to the world space 
+    // transform the vectors to the world space
     vec3 T = normalize(normalMatrix * aTangetn);
     vec3 N = normalize(normalMatrix * aNormal);
     T = normalize(T - dot(T, N) * N);
     vec3 B = cross(N, T);
-    
+
     // create the TBN matrix
     mat3 TBN = transpose(mat3(T,B,N));
 
@@ -47,10 +44,6 @@ void main()
     vs_out.FragPosLight = lightMatrix * vec4(vs_out.FragPos ,1.0);
     vs_out.hasNormalMap = hasNormalMap;
     vs_out.TBN = TBN;
-
-    vs_out.hasEmission= hasEmission;
-    vs_out.isModel = isModel;
-    vs_out.reciviesShadow = reciviesShadow;
 
     gl_Position = projection * view * vec4(vs_out.FragPos, 1.0);
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -24,23 +24,8 @@ int main() {
     auto pabloRenderer = PabloRenderer::getInstance();
     pabloRenderer->init();
 
-    auto PBRShader = std::make_shared<Shader>("VertexShader/PBR/PBRVertex.glsl", "FragmentShader/PBR/PBRFragmentTextures.glsl", "PBR shader");
-    auto PBRColorShader = std::make_shared<Shader>("VertexShader/PBR/PBRVertex.glsl", "FragmentShader/PBR/PBRFragment.glsl", "PBR shader2");
-    auto PBRTexturedModel = std::make_shared<Shader>("VertexShader/PBR/PBRVertex.glsl", "FragmentShader/PBR/PBRFragment-Textured-Model.glsl", "PBRTexturedModel");
-    auto shadowMapShader = std::make_shared<Shader>("VertexShader/AdvancedLightning/ShadowMapVertex.glsl", "FragmentShader/AdvancedLightning/ShadowMapFragement.glsl", "shadow map");
-    auto floorShader = std::make_shared<Shader>("VertexShader/FloorVertex.glsl", "FragmentShader/FloorFragment.glsl", "floor");
-    auto finalShaderStage = std::make_shared<Shader>("VertexShader/AdvancedLightning/FinalVertex.glsl", "FragmentShader/AdvancedLightning/FinalFragment.glsl", "final shader");
-    auto hdrToCubeMapShader = std::make_shared<Shader>("VertexShader/PBR/HDRtoCubeMapVertex.glsl", "FragmentShader/PBR/HDRtoCubeMapFragment.glsl", "Cube map shader");
-    auto skyBoxShader = std::make_shared<Shader>("VertexShader/PBR/SkyBoxVertex.glsl", "FragmentShader/PBR/SkyBoxFragment.glsl", "Sky box shader");
-    auto brdfLutTextureShader = std::make_shared<Shader>("VertexShader/PBR/LutTextureVertex.glsl", "FragmentShader/PBR/BRDFLutFragment.glsl", "LUT_Textue map");
-    auto lutDebug = std::make_shared<Shader>("VertexShader/LutTextureDebugVertex.glsl", "FragmentShader/LutTextureDebugFragment.glsl", "LUT_Texture_qDEBUG");
-    auto proceduralFloorTextureShader = std::make_shared<Shader>("VertexShader/FloorGridVertex.glsl", "FragmentShader/FloorGridFragment.glsl", "Floor grid baker");
-
-    auto PBRTexutreIBLOBJ = std::make_shared<Shader>("VertexShader/PBR/PBRVertex.glsl","FragmentShader/PBR/PBRFragment-IBL-textured-object.glsl", "PBR For simple geometry");
-    PBRTexutreIBLOBJ->supportsIBL = true;
-
-    auto PBRTexturedModelIBL = std::make_shared<Shader>("VertexShader/PBR/PBRVertex.glsl", "FragmentShader/PBR/PBRFragment-IBL-textured.glsl", "PBR_IBL");
-    PBRTexturedModelIBL->supportsIBL = true;
+    auto PBRShader = std::make_shared<Shader>("VertexShader/PBR/PBRVertex-Simple.glsl", "FragmentShader/PBR/PBRFragmentTextures.glsl", "PBR shader");
+    auto PBRColorShader = std::make_shared<Shader>("VertexShader/PBR/PBRVertex-Simple.glsl", "FragmentShader/PBR/PBRFragment.glsl", "PBR shader2");
 
     auto iblPipeLine = std::make_shared<IBLPipeLine>("Assets/Textures/HDR/garden.hdr");
     iblPipeLine->generateIBLTextures();
@@ -49,36 +34,36 @@ int main() {
     auto planeGeometry = std::make_shared<PlaneGeometry>();
     auto sphereGeometry = std::make_shared<SphereGeometry>();
 
-    auto skyBox = std::make_unique<SkyBoxMaterial>(std::move(skyBoxShader), *iblPipeLine->envMap, "enviromentMap");
+    auto skyBox = std::make_unique<SkyBoxMaterial>(*iblPipeLine->envMap, "enviromentMap");
 
     //create renderable object
     auto skyboxCube = std::make_unique<Renderable>(cubeGeometry, std::move(skyBox));
 
     auto gridRenderable = std::make_unique<Grid>();
 
-    auto goldCubeMaterial = std::make_shared<PBRTextured>(PBRTexutreIBLOBJ, "Assets/Textures/PBR/Gold");
-    auto wall = std::make_shared<PBRTextured>(PBRTexutreIBLOBJ, "Assets/Textures/PBR/Sand");
+    auto goldCubeMaterial = std::make_shared<PBRTextured>("Assets/Textures/PBR/Gold");
+    auto wall = std::make_shared<PBRTextured>("Assets/Textures/PBR/Sand");
     auto goldCubeRenderable = std::make_unique<Renderable>(sphereGeometry, goldCubeMaterial);
     goldCubeRenderable->transformations->setPosition(-3.0f, 1.0f, 0.0f);
     goldCubeRenderable->castsShadwo = true;
 
-    auto sunbro_helmet = std::make_unique<ModelSceneNode>(PBRTexturedModelIBL, "Assets/Model/sunbro_helmet/scene.gltf");
+    auto sunbro_helmet = std::make_unique<ModelSceneNode>("Assets/Model/sunbro_helmet/scene.gltf");
     sunbro_helmet->transformation->setRotations(glm::vec3(-90.0f, 0.0f, 00.0f));
     sunbro_helmet->transformation->setPosition(glm::vec3(0.0F, 2.0F, 0.0f));
     sunbro_helmet->transformation->setScale(glm::vec3(0.07f));
     sunbro_helmet->castsShadow(true);
 
-    auto sword  = std::make_unique<ModelSceneNode>(PBRTexturedModelIBL, "Assets/Model/sword/scene.gltf");
+    auto sword  = std::make_unique<ModelSceneNode>("Assets/Model/sword/scene.gltf");
     sword->transformation->setScale(glm::vec3(0.09f));
     sword->transformation->setPosition(glm::vec3(5.0f, 2.0f, 0.0f));
     sword->castsShadow(true);
 
-    auto pot = std::make_unique<ModelSceneNode>(PBRTexturedModelIBL, "Assets/Model/pot/brass_pot_01_2k.gltf");
+    auto pot = std::make_unique<ModelSceneNode>("Assets/Model/pot/brass_pot_01_2k.gltf");
     pot->transformation->setPosition(-5.0f, 0.0f, 0.0f);
     pot->transformation->setScale(4.0f, 4.0f, 4.0f);
     pot->castsShadow(true);
 
-    auto withcerMedailon = std::make_unique<ModelSceneNode>(PBRTexturedModelIBL, "Assets/Model/witcher_medalion/scene.gltf");
+    auto withcerMedailon = std::make_unique<ModelSceneNode>( "Assets/Model/witcher_medalion/scene.gltf");
     withcerMedailon->transformation->setRotations(glm::vec3(-90.0f, -90.0f, 0.0f));
     withcerMedailon->transformation->setPosition(glm::vec3(10.0f, 2.0f, 0.0f));
     withcerMedailon->transformation->setScale(glm::vec3(0.3));

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -41,8 +41,8 @@ int main() {
 
     auto gridRenderable = std::make_unique<Grid>();
 
-    auto goldCubeMaterial = std::make_shared<PBRTextured>("Assets/Textures/PBR/Gold");
-    auto wall = std::make_shared<PBRTextured>("Assets/Textures/PBR/Sand");
+    auto goldCubeMaterial = std::make_shared<PBRTextured>("Assets/Textures/PBR/Gold", true);
+    auto wall = std::make_shared<PBRTextured>("Assets/Textures/PBR/Sand", true);
     auto goldCubeRenderable = std::make_unique<Renderable>(sphereGeometry, goldCubeMaterial);
     goldCubeRenderable->transformations->setPosition(-3.0f, 1.0f, 0.0f);
     goldCubeRenderable->castsShadwo = true;


### PR DESCRIPTION
Shaders no longer have to be passed to the constructor of matrial class as each material class is handling shaders by itself
the only difference is in the `BasicTextureMaterial` as it is being passed to the `Frame Buffers` and they preform various actions that require unique shaders