### PR TITLE
vertecies and indecies are lodaded in separate threades

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ add_executable(${CMAKE_PROJECT_NAME}
         ${SOURCES}
         ${HEADERS}
         3rdPartyLybraries/Includes/ImGuiFileDialog/ImGuiFileDialog.cpp
+        Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.cpp
+        Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.h
 )
 
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES

--- a/Includes/Renderer/SceneGraph/ModelSceneNode/ModelSceneNode.h
+++ b/Includes/Renderer/SceneGraph/ModelSceneNode/ModelSceneNode.h
@@ -11,13 +11,16 @@
 #include <assimp/ai_assert.h>
 #include <assimp/scene.h>
 #include <vector>
+#include "thread"
 #include "Renderer/SceneGraph/SceneNode/SceneNode.h"
+#include "Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.h"
 
 class ModelSceneNode:public SceneNode  {
 public:
     explicit ModelSceneNode(std::string path, bool supportsAreaLight = false,  std::shared_ptr<Material> mat = nullptr, std::string name = "");
     std::string directory;
     std::string name;
+
     /***
      * Sets if the model is casting shadow
      * @param hasShadow bool is model an occluder @def false
@@ -42,6 +45,8 @@ private:
     bool hasEmissionTexture = false;
     int processedRenderableCount = 0;
     std::vector<std::shared_ptr<Texture2D>>loadedTextures;
+
+    std::vector<std::thread> threads;
 
     /***
      * Process node of the model from the assets

--- a/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.cpp
+++ b/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.cpp
@@ -1,0 +1,70 @@
+//
+// Created by wpsimon09 on 12/05/24.
+//
+
+#include "ModelLoaderHelper.h"
+
+void ModelLoaderHelper::processVertecies(std::vector<Vertex> &vertecies, aiMesh *mesh, const aiScene *scene) {
+    for (unsigned int i = 0; i < mesh->mNumVertices; i++) {
+        Vertex vertex;
+        //proccess vertex positions
+        glm::vec3 tempVertex;
+        tempVertex.x = mesh->mVertices[i].x;
+        tempVertex.y = mesh->mVertices[i].y;
+        tempVertex.z = mesh->mVertices[i].z;
+        vertex.position = tempVertex;
+
+        if (mesh->HasNormals()) {
+
+            //process texture coordinates
+            tempVertex.x = mesh->mNormals[i].x;
+            tempVertex.y = mesh->mNormals[i].y;
+            tempVertex.z = mesh->mNormals[i].z;
+
+            vertex.normals = tempVertex;
+
+        }
+
+        //process normal vectors
+        glm::vec2 tempTexCoords;
+
+        if (mesh->mTextureCoords[0]) {
+            //asimp allows for 8 different texture coorinates per verex
+            //but we are only interted in the first one
+            tempTexCoords.x = mesh->mTextureCoords[0][i].x;
+            tempTexCoords.y = mesh->mTextureCoords[0][i].y;
+            vertex.uv = tempTexCoords;
+
+            glm::vec3 tempTangent, tempBitanget;
+            if(mesh->mTangents){
+                tempTangent.x = mesh->mTangents[i].x;
+                tempTangent.y = mesh->mTangents[i].y;
+                tempTangent.z = mesh->mTangents[i].z;
+            }
+
+            vertex.tangent = tempTangent;
+
+            if(mesh->mBitangents){
+                tempBitanget.x = mesh->mBitangents[i].x;
+                tempBitanget.y = mesh->mBitangents[i].y;
+                tempBitanget.z = mesh->mBitangents[i].z;
+            }
+            vertex.bitangent = tempBitanget;
+        } else
+            vertex.uv = glm::vec2(0.0f, 0.0f);
+        vertecies.push_back(vertex);
+    }
+
+}
+
+void ModelLoaderHelper::processIndecies(std::vector<unsigned int> &indecies, aiMesh *mesh) {
+    for (unsigned int i = 0; i < mesh->mNumFaces; i++)
+    {
+        aiFace face = mesh->mFaces[i];
+
+        for (unsigned int j = 0; j < face.mNumIndices; j++)
+        {
+            indecies.push_back(face.mIndices[j]);
+        }
+    }
+}

--- a/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.h
+++ b/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.h
@@ -1,0 +1,21 @@
+//
+// Created by wpsimon09 on 12/05/24.
+//
+
+#ifndef PABLO_RENDERER_MODELLOADERHELPER_H
+#define PABLO_RENDERER_MODELLOADERHELPER_H
+
+#include "Renderer/Utils/Vertex/Vertex.h"
+#include "assimp/mesh.h"
+#include "assimp/scene.h"
+#include "vector"
+
+class ModelLoaderHelper {
+public:
+    static void processVertecies( std::vector<Vertex> &vertecies,aiMesh* mesh, const aiScene* scene );
+
+    static void processIndecies(std::vector<unsigned int>&indecies, aiMesh*mesh);
+};
+
+
+#endif //PABLO_RENDERER_MODELLOADERHELPER_H


### PR DESCRIPTION
indecies and vertecies are now loaded by separate threades, due to the fact that OpenGL is not thread safe i can not make the whole process of model loading multithreaded as I would have to rewrite significant chunk of the software and I aint doing it just now 

- the main bottle neck are Textures 
- models without textures and with just standard engine-native martial are loaded in less than 3 seconds 