### PR TITLE
Assets manager on loading model

### DIFF
--- a/Includes/Renderer/Material/Material.h
+++ b/Includes/Renderer/Material/Material.h
@@ -29,7 +29,7 @@ struct PBRMaterial {
      * @param samplerid sampler that is used for the textures
      */
     PBRMaterial(std::shared_ptr<T> type, std::string shaderName, int samplerid = 0) {
-        this->type = std::move(type);
+        this->type = type;
         this->shaderName = shaderName;
         this->samplerID = samplerid;
     }
@@ -41,7 +41,7 @@ struct PBRMaterial {
      * @param samplerid sampler that is used for the textures
      */
     PBRMaterial(T type, std::string shaderName, int samplerid = 0) {
-        this->type = std::make_unique<T>(std::move(type));
+        this->type = std::make_shared<T>(type);
         this->shaderName = shaderName;
         this->samplerID = samplerid;
     }

--- a/Includes/Renderer/SceneGraph/ModelSceneNode/ModelSceneNode.cpp
+++ b/Includes/Renderer/SceneGraph/ModelSceneNode/ModelSceneNode.cpp
@@ -98,7 +98,7 @@ void ModelSceneNode::processRenderable(aiMesh *mesh, const aiScene *scene) {
 std::unique_ptr<PBRTextured>ModelSceneNode::processRenderableMaterial(aiMaterial *meshMaterial) {
     std::unique_ptr<PBRTextured> mat = std::make_unique<PBRTextured>(this->supportsAreaLight);
 
-    std::vector<std::shared_ptr<Texture2D>> materialTextures;
+    std::vector<PBRMaterial<std::shared_ptr<Texture2D>>> materialTextures;
 
     std::vector<std::thread> textureThreads;
 
@@ -120,10 +120,9 @@ std::unique_ptr<PBRTextured>ModelSceneNode::processRenderableMaterial(aiMaterial
      * @brief assign names and samplers
      */
     int i = 0;
-    for(auto &textureToLoad : materialTextures){
-        auto newTexture = std::make_unique<PBRMaterial<Texture2D>>(textureToLoad, textureToLoad->shaderName, textureToLoad->samplerID);
-        newTexture->type->passToOpenGL();
-        mat->addTexture(std::move(newTexture));
+    for(auto textureToLoad : materialTextures){
+        textureToLoad.type->get()->passToOpenGL();
+        mat->addTexture(std::move(textureToLoad));
         i++;
     }
 

--- a/Includes/Renderer/SceneGraph/ModelSceneNode/ModelSceneNode.cpp
+++ b/Includes/Renderer/SceneGraph/ModelSceneNode/ModelSceneNode.cpp
@@ -98,7 +98,7 @@ void ModelSceneNode::processRenderable(aiMesh *mesh, const aiScene *scene) {
 std::unique_ptr<PBRTextured>ModelSceneNode::processRenderableMaterial(aiMaterial *meshMaterial) {
     std::unique_ptr<PBRTextured> mat = std::make_unique<PBRTextured>(this->supportsAreaLight);
 
-    std::vector<PBRMaterial<std::shared_ptr<Texture2D>>> materialTextures;
+    std::vector<std::unique_ptr<PBRMaterial<Texture2D>>> materialTextures;
 
     std::vector<std::thread> textureThreads;
 
@@ -120,8 +120,8 @@ std::unique_ptr<PBRTextured>ModelSceneNode::processRenderableMaterial(aiMaterial
      * @brief assign names and samplers
      */
     int i = 0;
-    for(auto textureToLoad : materialTextures){
-        textureToLoad.type->get()->passToOpenGL();
+    for(auto &textureToLoad : materialTextures){
+        textureToLoad->type->passToOpenGL();
         mat->addTexture(std::move(textureToLoad));
         i++;
     }

--- a/Includes/Renderer/Utils/AssetsManager/AssetsManager.cpp
+++ b/Includes/Renderer/Utils/AssetsManager/AssetsManager.cpp
@@ -24,6 +24,18 @@ std::shared_ptr<Texture2D> AssetsManager::getTexture(std::string path) {
         return loadSingleTexture(path.c_str(), true);
 }
 
+std::shared_ptr<Texture2D> AssetsManager::getTextureOnThread(std::string path) {
+    auto tex = loadedTextures.find(path);
+    if(tex != loadedTextures.end()){
+        return tex->second;
+    }else{
+        std::lock_guard<std::mutex> lock(textureLock);
+        loadedTextures.insert(std::make_pair(path, std::make_shared<Texture2D>(path.c_str(),true, false)));
+    }
+    return loadedTextures.end()->second;
+}
+
+
 
 std::vector<std::shared_ptr<Texture2D>> AssetsManager::getMultipleTextures(std::vector<std::string> paths) {
     std::vector<std::shared_ptr<Texture2D>> textures;
@@ -77,4 +89,14 @@ AssetsManager *AssetsManager::getInstance() {
         return AssetsManager::instance;
     }
 }
+
+void AssetsManager::loadTexturesToOpenGL() {
+    for(auto &texture: loadedTextures){
+        if(texture.second->isInGL){
+            texture.second->passToOpenGL();
+        }else
+            continue;
+    }
+}
+
 

--- a/Includes/Renderer/Utils/AssetsManager/AssetsManager.cpp
+++ b/Includes/Renderer/Utils/AssetsManager/AssetsManager.cpp
@@ -30,9 +30,10 @@ std::shared_ptr<Texture2D> AssetsManager::getTextureOnThread(std::string path) {
         return tex->second;
     }else{
         std::lock_guard<std::mutex> lock(textureLock);
-        loadedTextures.insert(std::make_pair(path, std::make_shared<Texture2D>(path.c_str(),true, false)));
+        auto newTexture = std::make_shared<Texture2D>(path.c_str(),true, false);
+        loadedTextures.insert(std::make_pair(path, newTexture));
+        return newTexture;
     }
-    return loadedTextures.end()->second;
 }
 
 

--- a/Includes/Renderer/Utils/AssetsManager/AssetsManager.h
+++ b/Includes/Renderer/Utils/AssetsManager/AssetsManager.h
@@ -20,7 +20,11 @@ public:
 
     std::vector<std::shared_ptr<Texture2D>> getMultipleTextures(std::vector<std::string> paths);
 
+    std::shared_ptr<Texture2D> getTextureOnThread(std::string path);
+
     std::shared_ptr<Texture2D> getTexture(std::string path);
+
+    void loadTexturesToOpenGL();
 
     ~AssetsManager() = default;
 

--- a/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.cpp
+++ b/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.cpp
@@ -96,7 +96,7 @@ void ModelLoaderHelper::processMaterialTexture(aiMaterial *material, MaterialToP
             ModelLoaderHelper::loadedTextures.push_back(std::move(newTexture));
             renderableMaterialTextures.push_back(loadedTextures.back());
         }*/
-        renderableMaterialTextures.push_back(assetsManagerInstance->getTexture(path.C_Str()));
+        renderableMaterialTextures.push_back(assetsManagerInstance->getTextureOnThread((directory +"/"+path.C_Str()).c_str()));
     }
     else
         return;

--- a/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.cpp
+++ b/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.cpp
@@ -79,6 +79,7 @@ void ModelLoaderHelper::processMaterialTexture(aiMaterial *material, MaterialToP
         if(materialToLoad.textureType == aiTextureType_EMISSIVE){
             ModelLoaderHelper::hasEmmisionTexture = true;
         }
+        /*
         for(auto &loaded_texture : ModelLoaderHelper::loadedTextures ){
             if(std::strcmp(loaded_texture->getRelativePath().c_str(), path.C_Str()) == 0){
                 renderableMaterialTextures.push_back(loaded_texture);
@@ -94,8 +95,10 @@ void ModelLoaderHelper::processMaterialTexture(aiMaterial *material, MaterialToP
             std::lock_guard<std::mutex> lock(ModelLoaderHelper::textureLock);
             ModelLoaderHelper::loadedTextures.push_back(std::move(newTexture));
             renderableMaterialTextures.push_back(loadedTextures.back());
-        }
-    }else
+        }*/
+        renderableMaterialTextures.push_back(assetsManagerInstance->getTexture(path.C_Str()));
+    }
+    else
         return;
 
 

--- a/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.cpp
+++ b/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.cpp
@@ -72,7 +72,7 @@ void ModelLoaderHelper::processIndecies(std::vector<unsigned int> &indecies, aiM
 }
 
 void ModelLoaderHelper::processMaterialTexture(aiMaterial *material, MaterialToProcess materialToLoad,
-                                               std::vector<PBRMaterial<std::shared_ptr<Texture2D>>> &renderableMaterialTextures) {
+                                               std::vector<std::unique_ptr<PBRMaterial<Texture2D>>> &renderableMaterialTextures) {
     aiString path;
 
     if(material->GetTexture(materialToLoad.textureType, 0, &path) == AI_SUCCESS){
@@ -97,8 +97,8 @@ void ModelLoaderHelper::processMaterialTexture(aiMaterial *material, MaterialToP
             renderableMaterialTextures.push_back(loadedTextures.back());
         }*/
         std::shared_ptr<Texture2D> newTexture = assetsManagerInstance->getTextureOnThread((directory +"/"+path.C_Str()).c_str());
-        auto newMaterial = PBRMaterial<std::shared_ptr<Texture2D>>(newTexture, materialToLoad.shaderName, materialToLoad.samplerNumber);
-        renderableMaterialTextures.push_back(newMaterial);
+        auto newMaterial = std::make_unique<PBRMaterial<Texture2D>>(newTexture, materialToLoad.shaderName, materialToLoad.samplerNumber);
+        renderableMaterialTextures.emplace_back(std::move(newMaterial));
     }
 
     else

--- a/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.cpp
+++ b/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.cpp
@@ -72,7 +72,7 @@ void ModelLoaderHelper::processIndecies(std::vector<unsigned int> &indecies, aiM
 }
 
 void ModelLoaderHelper::processMaterialTexture(aiMaterial *material, MaterialToProcess materialToLoad,
-                                               std::vector<std::shared_ptr<Texture2D>>& renderableMaterialTextures) {
+                                               std::vector<PBRMaterial<std::shared_ptr<Texture2D>>> &renderableMaterialTextures) {
     aiString path;
 
     if(material->GetTexture(materialToLoad.textureType, 0, &path) == AI_SUCCESS){
@@ -96,11 +96,13 @@ void ModelLoaderHelper::processMaterialTexture(aiMaterial *material, MaterialToP
             ModelLoaderHelper::loadedTextures.push_back(std::move(newTexture));
             renderableMaterialTextures.push_back(loadedTextures.back());
         }*/
-        renderableMaterialTextures.push_back(assetsManagerInstance->getTextureOnThread((directory +"/"+path.C_Str()).c_str()));
+        std::shared_ptr<Texture2D> newTexture = assetsManagerInstance->getTextureOnThread((directory +"/"+path.C_Str()).c_str());
+        auto newMaterial = PBRMaterial<std::shared_ptr<Texture2D>>(newTexture, materialToLoad.shaderName, materialToLoad.samplerNumber);
+        renderableMaterialTextures.push_back(newMaterial);
     }
+
     else
         return;
-
-
 }
+
 

--- a/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.h
+++ b/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.h
@@ -11,6 +11,7 @@
 #include "assimp/scene.h"
 #include <assimp/ai_assert.h>
 #include "Renderer/Utils/ModelLoaderHelpers/MaterialsToProcess.h"
+#include "Renderer/Utils/AssetsManager/AssetsManager.h"
 
 #include "vector"
 #include "memory"
@@ -24,6 +25,9 @@ private:
     inline static std::vector<std::shared_ptr<Texture2D>> loadedTextures;
     inline static bool hasEmmisionTexture = false;
     inline static std::string directory;
+
+    inline static AssetsManager* assetsManagerInstance = AssetsManager::getInstance();
+
 
 public:
     static void processVertecies( std::vector<Vertex> &vertecies,aiMesh* mesh, const aiScene* scene );

--- a/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.h
+++ b/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.h
@@ -12,6 +12,7 @@
 #include <assimp/ai_assert.h>
 #include "Renderer/Utils/ModelLoaderHelpers/MaterialsToProcess.h"
 #include "Renderer/Utils/AssetsManager/AssetsManager.h"
+#include "Renderer/Material/Material.h"
 
 #include "vector"
 #include "memory"
@@ -34,7 +35,7 @@ public:
 
     static void processIndecies(std::vector<unsigned int>&indecies, aiMesh*mesh);
 
-    static void processMaterialTexture(aiMaterial *material, MaterialToProcess materialToLoad, std::vector<std::shared_ptr<Texture2D>> &renderableMaterialTextures);
+    static void processMaterialTexture(aiMaterial *material, MaterialToProcess materialToLoad, std::vector<PBRMaterial<std::shared_ptr<Texture2D>>> &renderableMaterialTextures);
 
     static void setDirectory(std::string dir) {ModelLoaderHelper::directory = dir;};
 

--- a/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.h
+++ b/Includes/Renderer/Utils/ModelLoaderHelpers/ModelLoaderHelper.h
@@ -35,7 +35,7 @@ public:
 
     static void processIndecies(std::vector<unsigned int>&indecies, aiMesh*mesh);
 
-    static void processMaterialTexture(aiMaterial *material, MaterialToProcess materialToLoad, std::vector<PBRMaterial<std::shared_ptr<Texture2D>>> &renderableMaterialTextures);
+    static void processMaterialTexture(aiMaterial *material, MaterialToProcess materialToLoad, std::vector<std::unique_ptr<PBRMaterial<Texture2D>>> &renderableMaterialTextures);
 
     static void setDirectory(std::string dir) {ModelLoaderHelper::directory = dir;};
 

--- a/Includes/Renderer/Utils/Texture/Texture2D/Texture2D.cpp
+++ b/Includes/Renderer/Utils/Texture/Texture2D/Texture2D.cpp
@@ -11,6 +11,7 @@ Texture2D::Texture2D(const char *path, bool isPBRMaterial, bool loadToGl):Textur
     this->type_string = "GL_TEXTURE_2D";
     this->internalFormat = GL_RGBA;
     if(loadToGl){
+        this->isInGL = true;
         glCreateTextures(GL_TEXTURE_2D, 1, &this->ID);
         glCheckError();
     }
@@ -30,6 +31,7 @@ Texture2D::Texture2D(int width, int height, float *data, GLenum format) {
     this->texWidth = width;
     this->texHeight = height;
     this->internalFormat = format;
+    this->isInGL = true;
 
     glCreateTextures(GL_TEXTURE_2D, 1, &this->ID);
     glCheckError();
@@ -62,6 +64,7 @@ Texture2D::Texture2D(int width, int height, GLenum foramt): TextureBase() {
     this->texWidth = width;
     this->texHeight = height;
     this->internalFormat = foramt;
+    this->isInGL = true;
 
     // ------------------
     // PBR_TEXTURE_MAPS GENERATION
@@ -112,7 +115,7 @@ void Texture2D::passToOpenGL() {
     if(textureData != nullptr){
         stbi_image_free(textureData);
     }
-
+    this->isInGL = true;
     textureData = nullptr;
 }
 

--- a/Includes/Renderer/Utils/Texture/TextureBase.h
+++ b/Includes/Renderer/Utils/Texture/TextureBase.h
@@ -53,6 +53,11 @@ public:
     std::string shaderName;
 
     /***
+     * @brief Boolean flag marking if texture data was loaded in GPU
+     */
+    bool isInGL = false;
+
+    /***
      * Sampler if the texture to be used in shader
      * this might be 0 or unused in some cases as the PBR material struct is sometimes handling samplers
      */

--- a/imgui.ini
+++ b/imgui.ini
@@ -39,7 +39,7 @@ Pos=0,559
 Size=1440,200
 
 [Window][Add renderable]
-Pos=542,385
+Pos=367,341
 Size=400,400
 
 [Window][Choose File##ChooseFileDlgKey]

--- a/imgui.ini
+++ b/imgui.ini
@@ -226,3 +226,7 @@ Column 0  Sort=0v
 RefScale=13
 Column 0  Sort=0v
 
+[Table][0xB3CF2CAB,4]
+RefScale=13
+Column 0  Sort=0v
+

--- a/imgui.ini
+++ b/imgui.ini
@@ -222,3 +222,7 @@ Column 0  Sort=0v
 RefScale=13
 Column 0  Sort=0v
 
+[Table][0x139E0E37,4]
+RefScale=13
+Column 0  Sort=0v
+

--- a/imgui.ini
+++ b/imgui.ini
@@ -20,11 +20,11 @@ Size=1920,1043
 
 [Window][ViewPort]
 Pos=500,10
-Size=940,739
+Size=1420,1001
 
 [Window][Tools]
-Pos=0,379
-Size=500,369
+Pos=0,510
+Size=500,500
 
 [Window][Application info]
 Pos=0,821
@@ -60,7 +60,7 @@ Size=967,510
 
 [Window][Scene]
 Pos=0,10
-Size=500,369
+Size=500,500
 
 [Window][Environment settings]
 Pos=739,301


### PR DESCRIPTION
Assets manager class is being used while loading models

it works nice when there is only one mesh, or multiple meshes not sharing the same material, it brakes when a textures is supposed to be shared